### PR TITLE
Call crop before save to apply changes on image

### DIFF
--- a/dist/react-image-editor.js
+++ b/dist/react-image-editor.js
@@ -50,6 +50,7 @@ var ImageEditorRc = function (_Component) {
     };
     _this.rotateToLeft = _this.rotateToLeft.bind(_this);
     _this.rotateToRight = _this.rotateToRight.bind(_this);
+    _this.crop = _this.crop.bind(_this);
     return _this;
   }
 
@@ -192,10 +193,10 @@ var ImageEditorRc = function (_Component) {
     }
   }, {
     key: 'crop',
-    value: function crop(options) {
+    value: function crop(options, cb) {
       this.setState({
         image: this.cropper.getCroppedCanvas(options)
-      });
+      }, cb);
     }
   }, {
     key: 'move',
@@ -352,7 +353,7 @@ var ImageEditorRc = function (_Component) {
             _react2.default.createElement(
               'button',
               { onClick: function onClick() {
-                  return _this5.saveImage();
+                  return _this5.crop(_this5.props, _this5.saveImage);
                 } },
               'Save'
             )

--- a/src/react-image-editor.js
+++ b/src/react-image-editor.js
@@ -56,6 +56,7 @@ class ImageEditorRc extends Component {
     };
     this.rotateToLeft = this.rotateToLeft.bind(this);
     this.rotateToRight = this.rotateToRight.bind(this);
+    this.crop = this.crop.bind(this);
   }
   componentDidMount() {
     const options = Object.keys(this.props)
@@ -176,10 +177,10 @@ class ImageEditorRc extends Component {
     return this.cropper.getData(rounded);
   }
 
-  crop(options) {
+  crop(options, cb) {
     this.setState({
       image: this.cropper.getCroppedCanvas(options),
-    });
+    }, cb);
   }
 
   move(offsetX, offsetY) {
@@ -283,7 +284,7 @@ class ImageEditorRc extends Component {
         <ul >
           <li><button onClick={() => this.rotateToRight()}>Rotate Right</button></li>
           <li><button onClick={() => this.rotateToLeft()}>Rotate Left</button></li>
-          <li><button onClick={() => this.saveImage()}>Save</button></li>
+          <li><button onClick={() => this.crop(this.props, this.saveImage)}>Save</button></li>
         </ul>
       </div>
     );


### PR DESCRIPTION
I was getting an error when saving, as `crop` was not being called and `image` was at its initial state as a string. 
This change call crop before save, and passes the `saveImage` as a callback to the `setState`, making sure that the image state is a Cropper object.